### PR TITLE
Add some export snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Every space inside `{ }` and `( )` means that this is pushed into next line :)
 |`imd→`|`import { destructuredModule } from 'module'`|
 |`ime→`|`import * as alias from 'module'`|
 |`ima→`|`import { originalName as aliasName} from 'module'`|
+|`exp→`|`export default moduleName`|
+|`exd→`|`export { destructuredModule } from 'module'`|
+|`exa→`|`export { originalName as aliasName} from 'module'`|
 |`enf→`|`export const functionName = (params) => { }`|
 |`edf→`|`export default (params) => { }`|
 |`met→`|`methodName = (params) => { }`|

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -21,6 +21,18 @@
     "prefix": "ima",
     "body": "import { ${2:originalName} as ${3:alias} } from '${1:module}'$0"
   },
+  "exportDefault": {
+    "prefix": "exp",
+    "body": "export default $1$0"
+  },
+  "exportDestructing": {
+    "prefix": "exd",
+    "body": "export { $2 } from '${1:module}'$0"
+  },
+  "exportAs": {
+    "prefix": "exa",
+    "body": "export { ${2:originalName} as ${3:alias} } from '${1:module}'$0"
+  },
   "exportNamedFunction": {
     "prefix": "enf",
     "body": [


### PR DESCRIPTION
I always tend to modulate my projects ([reference](https://github.com/erikras/ducks-modular-redux)), so I usually have a `index.js` file with something like this:

```
export { default as Component } from './component';
export { default as actions } from './actions';
export { default } from './reducers';
export { default as sagas } from './sagas';
```

I have this snippets in my VSCode, but I decided to add in this project because maybe they'll be useful to someone else.