### PR TITLE
fix typo in rcredux missing '('

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -444,7 +444,7 @@
       "  ",
       "}",
       "",
-      "export default connect(mapStateToProps, mapDispatchToProps)${1:TM_FILENAME_BASE})",
+      "export default connect(mapStateToProps, mapDispatchToProps)(${1:TM_FILENAME_BASE})",
       ""
     ],
     "description":


### PR DESCRIPTION
for the last line of the `rcredux` snippet I was getting

```js
export default connect(mapStateToProps, mapDispatchToProps)TM_FILENAME_BASE)
```

rather than

```js
export default connect(mapStateToProps, mapDispatchToProps)(TM_FILENAME_BASE)
```