### PR TITLE
:bug: Fixed rfcp by defining component name

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -315,7 +315,7 @@
       "import React from 'react'",
       "import PropTypes from 'prop-types'",
       "",
-      "export default () => {",
+      "const ${1:${TM_FILENAME_BASE}} = () => {",
       "  return (",
       "    <div>",
       "      $0",
@@ -326,6 +326,9 @@
       "${1:${TM_FILENAME_BASE}}.propTypes = {",
       "",
       "}",
+      "",
+      "export default ${1:${TM_FILENAME_BASE}}",
+      "",
       ""
     ],
     "description": "Creates a React Functional Component with ES7 module system with PropTypes"


### PR DESCRIPTION
Can't apply proptypes outside of a class/function without using a named function. 

This change defines the component function by the filename, and exports it separately (since directly exported const aren't supported).