### PR TITLE
Add snippets for React functional and anonymous functional components

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,25 +250,13 @@ export default class FileName extends Component {
 }
 ```
 
-### `rfe`
-
-```javascript
-import React from 'react'
-
-const $1 = props => {
-  return <div>$0</div>
-}
-
-export default $1
-```
-
-### `rfep`
+### `rfcp`
 
 ```javascript
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const $1 = props => {
+function $1() {
   return <div>$0</div>
 }
 
@@ -282,7 +270,7 @@ export default $1
 ```javascript
 import React from 'react'
 
-export default () => {
+export default function $1() {
   return <div>$0</div>
 }
 ```
@@ -292,24 +280,46 @@ export default () => {
 ```javascript
 import React from 'react'
 
-const $1 = () => {
+function $1() {
   return <div>$0</div>
 }
 
 export default $1
 ```
 
-### `rfcp`
+### `rafcp`
 
 ```javascript
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const $1 = () => {
+const $1 = props => {
   return <div>$0</div>
 }
 
 $1.propTypes = {}
+
+export default $1
+```
+
+### `rafc`
+
+```javascript
+import React from 'react'
+
+export default () => {
+  return <div>$0</div>
+}
+```
+
+### `rafce`
+
+```javascript
+import React from 'react'
+
+const $1 = () => {
+  return <div>$0</div>
+}
 
 export default $1
 ```

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -251,7 +251,7 @@
     "body": [
       "import React from 'react'",
       "",
-      "const ${1:${TM_FILENAME_BASE}} = () => {",
+      "function ${1:${TM_FILENAME_BASE}}() {",
       "  return (",
       "    <div>",
       "      $0",
@@ -269,7 +269,7 @@
     "body": [
       "import React from 'react'",
       "",
-      "export default () => {",
+      "export default function ${1:${TM_FILENAME_BASE}}() {",
       "  return (",
       "    <div>",
       "      $0",
@@ -282,6 +282,64 @@
   },
   "reactFunctionalComponentWithPropTypes": {
     "prefix": "rfcp",
+    "body": [
+      "import React from 'react'",
+      "import PropTypes from 'prop-types'",
+      "",
+      "function ${1:${TM_FILENAME_BASE}}() {",
+      "  return (",
+      "    <div>",
+      "      $0",
+      "    </div>",
+      "  )",
+      "}",
+      "",
+      "${1:${TM_FILENAME_BASE}}.propTypes = {",
+      "",
+      "}",
+      "",
+      "export default ${1:${TM_FILENAME_BASE}}",
+      "",
+      ""
+    ],
+    "description": "Creates a React Functional Component with ES7 module system with PropTypes"
+  },
+  "reactAnonymousFunctionalExportComponent": {
+    "prefix": "rafce",
+    "body": [
+      "import React from 'react'",
+      "",
+      "const ${1:${TM_FILENAME_BASE}} = () => {",
+      "  return (",
+      "    <div>",
+      "      $0",
+      "    </div>",
+      "  )",
+      "}",
+      "",
+      "export default ${1:${TM_FILENAME_BASE}}",
+      ""
+    ],
+    "description": "Creates a React Anonymous Functional Component with ES7 module system"
+  },
+  "reactAnonymousFunctionalComponent": {
+    "prefix": "rafc",
+    "body": [
+      "import React from 'react'",
+      "",
+      "export default const ${1:${TM_FILENAME_BASE}} = () => {",
+      "  return (",
+      "    <div>",
+      "      $0",
+      "    </div>",
+      "  )",
+      "}",
+      ""
+    ],
+    "description": "Creates a React Anonymous Functional Component with ES7 module system"
+  },
+  "reactAnonymousFunctionalComponentWithPropTypes": {
+    "prefix": "rafcp",
     "body": [
       "import React from 'react'",
       "import PropTypes from 'prop-types'",


### PR DESCRIPTION
Anonymous functions are difficult to debug in the browser dev tools and React dev tools. Not having a name makes it difficult to know where the error resides.

The React Core team uses traditional named functions for functional components throughout the official documentation.

I left snippets for Anonymous and Arrow React functional components for those who prefer this style.

At the end of the day, this doesn't matter, but it'd be nice to have the option of both `function Foo() {}` and `const Foo = () => {}`