### PR TITLE
Change getDerivedStateFromProps description and parameter names

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -641,8 +641,8 @@
   },
   "getDerivedStateFromProps": {
     "prefix": "gdsfp",
-    "body": ["static getDerivedStateFromProps(nextProps, prevState) {", "  ${1}", "}"],
-    "description": "Invoked after a component is instantiated as well as when it receives new props."
+    "body": ["static getDerivedStateFromProps(props, state) {", "  ${1}", "}"],
+    "description": "Invoked right before calling the render method, both on the initial mount and on subsequent updates."
   },
   "getSnapshotBeforeUpdate": {
     "prefix": "gsbu",


### PR DESCRIPTION
Description: This lifecycle method is called on every update (including setState), not only when it receives new props. 

Body: There is no access to old props and the contract in official React documentation specifies static getDerivedStateFromProps(props, state) we should stick to the same naming convention https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops

Closes #49 