### PR TITLE
Add search snippet command through 'ES7 snippet search command'

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,0 +1,49 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const vscode = require('vscode');
+const snippets = require('./snippets/snippets.json');
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+  console.log(
+    'Congratulations, your extension "snippet-search" is now active!'
+  );
+
+  let disposable = vscode.commands.registerCommand(
+    'extension.snippetSearch',
+    () => {
+      const items = Object.entries(snippets).map(
+        ([shortDescription, { prefix, body, description }], id) => ({
+          id,
+          description: description || shortDescription,
+          label: prefix,
+          value: prefix,
+          body,
+        })
+      );
+      const options = {
+        matchOnDescription: true,
+        matchOnDetail: true,
+        placeHolder: 'Search snippet',
+      };
+      vscode.window.showQuickPick(items, options).then(item => {
+        const activeTextEditor = vscode.window.activeTextEditor;
+        activeTextEditor &&
+          activeTextEditor.insertSnippet(new vscode.SnippetString(item.body));
+      });
+    }
+  );
+  context.subscriptions.push(disposable);
+}
+exports.activate = activate;
+
+function deactivate() {}
+
+module.exports = {
+  activate,
+  deactivate,
+};

--- a/package.json
+++ b/package.json
@@ -24,7 +24,17 @@
   "categories": [
     "Snippets"
   ],
+  "main": "./extension.js",
+  "activationEvents": [
+    "onCommand:extension.snippetSearch"
+  ],
   "contributes": {
+    "commands": [
+      {
+        "command": "extension.snippetSearch",
+        "title": "ES7 snippet search"
+      }
+    ],
     "snippets": [
       {
         "language": "javascript",
@@ -43,5 +53,16 @@
         "path": "./snippets/snippets.json"
       }
     ]
+  },
+  "scripts": {
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "node ./node_modules/vscode/bin/test"
+  },
+  "devDependencies": {
+    "typescript": "^3.1.4",
+    "vscode": "^1.1.25",
+    "eslint": "^4.11.0",
+    "@types/node": "^8.10.25",
+    "@types/mocha": "^2.2.42"
   }
 }


### PR DESCRIPTION
With this pull request this extension is no longer a simple snippet extension.
Day to day, I forgot the snippet short links. With this PR you have another command "ES7 snippet search" where you can search through module snippets.
Relative to my last comment in this issue #8 

Faster, Better, Stronger ;-) 