### PR TITLE
Unnecessary binding

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -712,7 +712,7 @@
   "componentWillMount": {
     "prefix": "cwm",
     "body": [
-      "componentWillMount = () => {",
+      "componentWillMount() {",
       "  $0",
       "}",
       ""
@@ -722,7 +722,7 @@
   "componentDidMount": {
     "prefix": "cdm",
     "body": [
-      "componentDidMount = () => {",
+      "componentDidMount() {",
       "  $0",
       "}",
       ""
@@ -732,7 +732,7 @@
   "componentWillReceiveProps": {
     "prefix": "cwr",
     "body": [
-      "componentWillReceiveProps = (nextProps) => {",
+      "componentWillReceiveProps(nextProps) {",
       "  $0",
       "}",
       ""
@@ -742,7 +742,7 @@
   "shouldComponentUpdate": {
     "prefix": "scu",
     "body": [
-      "shouldComponentUpdate = (nextProps, nextState) => {",
+      "shouldComponentUpdate(nextProps, nextState) {",
       "  $0",
       "}",
       ""
@@ -752,7 +752,7 @@
   "componentWillUpdate": {
     "prefix": "cwup",
     "body": [
-      "componentWillUpdate = (nextProps, nextState) => {",
+      "componentWillUpdate(nextProps, nextState) {",
       "  $0",
       "}",
       ""
@@ -762,7 +762,7 @@
   "componentDidUpdate": {
     "prefix": "cdup",
     "body": [
-      "componentDidUpdate = (prevProps, prevState) => {",
+      "componentDidUpdate(prevProps, prevState) {",
       "  $0",
       "}",
       ""
@@ -772,7 +772,7 @@
   "componentWillUnmount": {
     "prefix": "cwun",
     "body": [
-      "componentWillUnmount = () => {",
+      "componentWillUnmount() {",
       "  $0",
       "}",
       ""


### PR DESCRIPTION
`extends Component` auto binds React methods. This is unnecessary.