### PR TITLE
Fix useEffect and useLayoutEffect snippets

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1235,10 +1235,11 @@
     "prefix": "useEffect",
     "body": [
       "useEffect(() => {",
+      "\t${1:effect}",
       "\treturn () => {",
-      "\t\t${1:effect}",
+      "\t\t${2:cleanup}",
       "\t};",
-      "}, [${2:input}])"
+      "}, [${3:input}])"
     ]
   },
   "useContext": {
@@ -1290,10 +1291,11 @@
     "prefix": "useLayoutEffect",
     "body": [
       "useLayoutEffect(() => {",
+      "\t${1:effect}",
       "\treturn () => {",
-      "\t\t${1:effect}",
+      "\t\t${2:cleanup}",
       "\t},",
-      "\t[${2:input}]",
+      "\t[${3:input}]",
       "})"
     ]
   }


### PR DESCRIPTION
Moves the `${1:effect}` tabstop out of the returned cleanup function and adds `${2:cleanup}` tabstop inside the returned function.

Fixes #74 