### PR TITLE
Update ts-snippets.json to import ReactElement

### DIFF
--- a/snippets/ts-snippets.json
+++ b/snippets/ts-snippets.json
@@ -58,7 +58,7 @@
   "typeScriptReactFunctionalExportComponent": {
     "prefix": "tsrfce",
     "body": [
-      "import React from 'react'",
+      "import React, { ReactElement } from 'react'",
       "",
       "interface Props {",
       "\t",
@@ -80,7 +80,7 @@
   "typeScriptReactFunctionalComponent": {
     "prefix": "tsrfc",
     "body": [
-      "import React from 'react'",
+      "import React, { ReactElement } from 'react'",
       "",
       "interface Props {",
       "\t",


### PR DESCRIPTION
We need to add `ReactElement` to the import statement for snippets `tsrfc` and `tsrfce`.