### PR TITLE
Add asynchronous test blocks

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1234,10 +1234,20 @@
     "body": ["test('should $1', () => {", "\t$0", "})", ""],
     "description": "Testing `test` block"
   },
+  "testAsyncBlock": {
+    "prefix": "testa",
+    "body": ["test('should $1', async () => {", "\t$0", "})", ""],
+    "description": "Testing `asynchronous test` block"
+  },
   "itBlock": {
     "prefix": "tit",
     "body": ["it('should $1', () => {", "\t$0", "})", ""],
     "description": "Testing `it` block"
+  },
+  "itAsyncBlock": {
+    "prefix": "tita",
+    "body": ["it('should $1', async () => {", "\t$0", "})", ""],
+    "description": "Testing asynchronous `it` block"
   },
   "setupReactTest": {
     "prefix": "stest",


### PR DESCRIPTION
I use the `tit` snipped a lot, but whenever I have async tests, I sometimes forget to add the `async` keyword before the arrow function. It would be great if there were snippets that cover this use case.

This PR adds two new snippets the create asynchronous tests:

* `testa` -> Creates a `test('should ', async () => {})` block
* `tita` -> Creates an `it('should ', async () => {})` block