### PR TITLE
Add styled-jsx snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ I.E. `tsrcc`
 | `rxreducer→` | `redux reducer template`  |
 |  `rxselect→` | `redux selector template` |
 
+## styled-jsx
+
+|  Prefix | Method                              |
+| ------: | ----------------------------------- |
+|  `sjsx` | ``<style jsx>{` `}</style>``        |
+| `sjsxg` | ``<style jsx global>{` `}</style>`` |
+
 ## PropTypes
 
 |    Prefix | Method                                   |
@@ -775,3 +782,4 @@ export default WrappedComponent => {
   return hocComponent
 }
 ```
+

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -884,6 +884,26 @@
       ""
     ]
   },
+  "styledJSX": {
+    "prefix": "sjsx",
+    "body": [
+      "<style jsx>{`",
+      "\t$0",
+      "`}</style>",
+      ""
+    ],
+    "description": "Creates a CSS style that is scoped to its React component"
+  },
+  "styledJSXGlobal": {
+    "prefix": "sjsxg",
+    "body": [
+      "<style jsx global>{`",
+      "\t$0",
+      "`}</style>",
+      ""
+    ],
+    "description": "Creates a CSS style that is global"
+  },
   "reactNativeComponent": {
     "prefix": "rnc",
     "body": [


### PR DESCRIPTION
[styled-jsx](https://github.com/vercel/styled-jsx) is commonly used in Next.js framework.

The reason I placed `styled-jsx` in its own section in the README, is because it is different than regular inline React style jsx. The CSS styles defined in `styled-jsx` are scoped to its React component, where as regular inline style jsx is global.