### PR TITLE
New ts rn snippet with named props interface

### DIFF
--- a/snippets/ts-snippets.json
+++ b/snippets/ts-snippets.json
@@ -246,6 +246,29 @@
     ],
     "description": "Creates a React Native Arrow Function Component with ES7 module system and TypeScript interface"
   },
+  "typescriptReactNativeArrowFunctionComponentNamedProps": {
+    "prefix": "tsrnfi",
+    "body": [
+      "import React from 'react'",
+      "import { View } from 'react-native'",
+      "",
+      "interface ${1:${TM_FILENAME_BASE}}Props {",
+      "\t",
+      "}",
+      "",
+      "const ${1:${TM_FILENAME_BASE}}: React.FunctionComponent<${1:${TM_FILENAME_BASE}}Props> = (props) => {",
+      "\treturn (",
+      "\t\t<View>",
+      "\t\t\t$0",
+      "\t\t</View>",
+      "\t)",
+      "}",
+      "",
+      "export default ${1:${TM_FILENAME_BASE}}",
+      ""
+    ],
+    "description": "Creates a React Native Arrow Function Component with ES7 module system and named TypeScript interface"
+  },
   "typescriptReactNativeArrowFunctionComponentWithStyles": {
     "prefix": "tsrnfs",
     "body": [


### PR DESCRIPTION
Hi,

Thanks for a great extension. I didn't find any contributing guidelines, so I hope it's okay to create a PR. Let me know if I've missed something.

`tsrnfi` creates the following snippet:
```tsx
import React from 'react'
import { View } from 'react-native'

interface MyComponentProps {
    
}

const MyComponent: React.FunctionComponent<MyComponentProps> = (props) => {
    return (
        <View>
            
        </View>
    )
}

export default MyComponent
```
<img width="644" alt="Screenshot 2020-06-26 at 11 41 07" src="https://user-images.githubusercontent.com/6067491/85838273-fbc79480-b7a1-11ea-810a-26c3668f1f65.png">

This snippet differs from the existing TypeScript snippets by using the `React.FunctionComponent` generic interface.

I'd suggest improving the types of all TypeScript snippets by actually typing the constant that holds the React component, as has been done in this PR, not simply the props. Even the types of `props` is more correct when typed this way, since e.g. `props.children` is automatically typed by the `React.FunctionComponent` generic.