### PR TITLE
fix vim plug in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ git clone https://github.com/dsznajder/vscode-es7-javascript-react-snippets.git 
 It is possible to use this package in your vim/neovim text editor, to make this possible, make sure you have the `coc.nvim` previously configured, then add this command to your `init.vim`
 
 ```shell
-Plug 'dsznajder/vscode-es7-javascript-react-snippets', { \ 'do': 'yarn install --frozen-lockfile && yarn compile' }
+Plug 'dsznajder/vscode-es7-javascript-react-snippets', { 'do': 'yarn install --frozen-lockfile && yarn compile' }
 ```
 
 Update your vim / neovim settings with `:source %` and then install the new package with `:PlugInstall`


### PR DESCRIPTION
The vim plug line is an invalid expression. The problem is the `\`: it needs to be omitted or moved to the next line:
```viml
Plug 'dsznajder/vscode-es7-javascript-react-snippets',
      \ { 'do': 'yarn install --frozen-lockfile && yarn compile' }
```