### PR TITLE
[Feat] - Add axios and styled-components snippets(fapi, scr, scrd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,37 @@ export default connect(mapStateToProps, mapDispatchToProps)(FileName)
 
 ## Others
 
+### `fapi`
+
+```javascript
+import axios from 'axios';
+
+const ${1:api} = axios.create({
+  baseURL: '${2:url}',
+});
+
+export default ${1:api};
+
+```
+
+### `scr`
+
+```javascript
+import styled from 'styled-components';
+
+export const ${1:Main} = styled.${2:div}`
+  ${3}
+`;
+```
+
+### `scrd`
+
+```javascript
+export const ${1:Main} = styled.${2:div}`
+  ${3}
+`;
+```
+
 ### `cmmb`
 
 ```JS

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -191,6 +191,23 @@
     "body": ["const { $1 } = this.state"],
     "description": "Creates and assigns a local variable using state destructing"
   },
+
+  "createApiFile": {
+    "prefix": "fapi",
+    "body": [
+      "import axios from 'axios';",
+      "",
+      "const ${1:api} = axios.create({",
+      "  baseURL: '${2:url}',",
+      "});",
+      "",
+      "export default ${1:api};",
+      ""
+    ],
+    "description": "create api file witch axios"
+  },
+
+
   "import React": {
     "prefix": "imr",
     "body": ["import React from 'react'", ""]
@@ -851,6 +868,30 @@
       "})",
       ""
     ]
+  },
+  "stylesComponents": {
+    "prefix": "scr",
+    "body": [
+      "import styled from 'styled-components';",
+      "",
+      "export const ${1:Main} = styled.${2:div}`",
+      "  ${3}",
+      "`;",
+      ""
+    ],
+    "description": "Create ReactJS Styled Components file"
+  },
+
+  "stylesComponentsDiv": {
+    "prefix": "scrd",
+    "body": [
+
+      "export const ${1:Main} = styled.${2:div}`",
+      "  ${3}",
+      "`;",
+      ""
+    ],
+    "description": "Create Div Styled Components"
   },
   "reduxConst": {
     "prefix": "rxconst",


### PR DESCRIPTION
Hi, i've been using your snippets and i liked a lot, but i feel it's missing a few things that i've been using lately like a styled-component snippet and an api one.

scr: Create a ReactJS Styled Components file

scrd: Create an exported style constant of Styled Components instance

fapi create an axios api file