### PR TITLE
delete new line at the end of `anfn`

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -78,7 +78,7 @@
   },
   "anonymousFunction": {
     "prefix": "anfn",
-    "body": ["(${1:params}) => {", "\t${2}", "}", ""],
+    "body": ["(${1:params}) => {", "\t${2}", "}"],
     "description": "Creates an anonymous function in ES7 syntax"
   },
   "namedFunction": {


### PR DESCRIPTION
do not insert new line at the end of `anfn`, it is frequently used in inline style, insert new line cause confusion.