### PR TITLE
Add redux-toolkit createSlice

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ I.E. `tsrcc`
 |   `rxconst→` | `export const $1 = '$1'`  |
 | `rxreducer→` | `redux reducer template`  |
 |  `rxselect→` | `redux selector template` |
+|   `rxslice→` | `redux slice template`    |
 
 ## PropTypes
 

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -885,6 +885,29 @@
       ""
     ]
   },
+  "reduxSlice": {
+    "prefix": "rxslice",
+    "body": [
+      "import { createSlice } from '@reduxjs/toolkit'",
+      "",
+      "const initialState = {",
+      "",
+      "}",
+      "",
+      "const ${1:${TM_FILENAME_BASE}} = createSlice({",
+      "\tname: ${2:sliceName},",
+      "\tinitialState,",
+      "\treducers: {",
+      "\t",
+      "\t}",
+      "});",
+      "",
+      "export const {",
+      "",
+      "} = ${1:${TM_FILENAME_BASE}}.actions",
+      "export default ${1:${TM_FILENAME_BASE}}.reducer"
+    ]
+  },
   "reactNativeComponent": {
     "prefix": "rnc",
     "body": [


### PR DESCRIPTION
Since maintainers of Redux promote Redux Toolkit as the new go-to way to use the library and recommend separating the state into smaller contained slices, I think having a snippet for [createSlice](https://redux-toolkit.js.org/api/createSlice) would be pretty handy. 