### PR TITLE
delete { Component } from rfcredux and rfcreduxp

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -692,7 +692,7 @@
       "}",
       "",
       "${1:${TM_FILENAME_BASE}}.propTypes = {",
-      "\t${2:prop}: ${3:PropTypes}",
+      "\t${2:props}: ${3:PropTypes}",
       "}",
       "",
       "const mapStateToProps = (state) => ({",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -652,10 +652,10 @@
   "reactFunctionalCompomentRedux": {
     "prefix": "rfcredux",
     "body": [
-      "import React, { Component } from 'react'",
+      "import React from 'react'",
       "import { connect } from 'react-redux'",
       "",
-      "export const ${1:${TM_FILENAME_BASE}} = () => {",
+      "export const ${1:${TM_FILENAME_BASE}} = (props) => {",
       "\treturn (",
       "\t\t<div>",
       "\t\t\t$0",
@@ -679,11 +679,11 @@
   "reactFunctionalCompomentReduxPropTypes": {
     "prefix": "rfcreduxp",
     "body": [
-      "import React, { Component } from 'react'",
+      "import React from 'react'",
       "import PropTypes from 'prop-types'",
       "import { connect } from 'react-redux'",
       "",
-      "export const ${1:${TM_FILENAME_BASE}} = () => {",
+      "export const ${1:${TM_FILENAME_BASE}} = (props) => {",
       "\treturn (",
       "\t\t<div>",
       "\t\t\t$0",


### PR DESCRIPTION
delete { Component } from rfcredux and rfcreduxp, because these are functional components and do not need them Component