### PR TITLE
Use string template literals for console snippets with string arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ I.E. `tsrcc`
 | Prefix | Method                              |
 | -----: | ----------------------------------- |
 | `clg→` | `console.log(object)`               |
-| `clo→` | `console.log("object", object)`     |
-| `ctm→` | `console.time("timeId")`            |
-| `cte→` | `console.timeEnd("timeId")`         |
+| `clo→` | ```console.log(`object`, object)``` |
+| `ctm→` | ```console.time(`timeId`)```        |
+| `cte→` | ```console.timeEnd(`timeId`)```     |
 | `cas→` | `console.assert(expression,object)` |
 | `ccl→` | `console.clear()`                   |
 | `cco→` | `console.count(label)`              |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -158,17 +158,17 @@
   },
   "consoleLogObject": {
     "prefix": "clo",
-    "body": "console.log('${1:object}', ${1:object})",
+    "body": "console.log(`${1:object}`, ${1:object})",
     "description": "Logs property with name."
   },
   "consoleTime": {
     "prefix": "ctm",
-    "body": "console.time('${1:object}')",
+    "body": "console.time(`${1:object}`)",
     "description": "Console time wrapper"
   },
   "consoleTimeEnd": {
     "prefix": "cte",
-    "body": "console.timeEnd('${1:object}')",
+    "body": "console.timeEnd(`${1:object}`)",
     "description": "Console time end wrapper"
   },
   "consoleWarn": {


### PR DESCRIPTION
This is backwards compatible and is a nice improvement so that when typing something like:

`clo ENTER someMethodCall('someString')` it simply works

(result of above would be:

```js
console.log(`someMethodCall('someString')`, someMethodCall('someString'));
```