### PR TITLE
Add snippet for react custom hook

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1852,15 +1852,15 @@
     ]
   },
   "reactCustomHook": {
-		"prefix": "rch",
-		"body": [
-		  "import {$1} from 'react'",
-		  "",
-		  "export default function ${2:${TM_FILENAME_BASE}}($3) => {",
-		   "\t$4",
-		  "}",
-		  ""
-		],
-		"description": "Creates a React Custom Hook with ES7 module system"
-	}
+    "prefix": "rch",
+    "body": [
+    	"import {$1} from 'react'",
+	"",
+	"export default function ${2:${TM_FILENAME_BASE}}($3) {",
+	"\t$4",
+	"}",
+	""
+     ],
+     "description": "Creates a React Custom Hook with ES7 module system"
+   },
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1862,5 +1862,5 @@
 	""
      ],
      "description": "Creates a React Custom Hook with ES7 module system"
-   },
+   }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1850,5 +1850,17 @@
       "}",
       ""
     ]
-  }
+  },
+  "reactCustomHook": {
+		"prefix": "rch",
+		"body": [
+		  "import {$1} from 'react'",
+		  "",
+		  "export default function ${2:${TM_FILENAME_BASE}}($3) => {",
+		   "\t$4",
+		  "}",
+		  ""
+		],
+		"description": "Creates a React Custom Hook with ES7 module system"
+	}
 }


### PR DESCRIPTION
Hey reader, 
Glad to see you're reading this, I was just creating some custom hooks in my projects and noticed that this very awesome VSCode extension doesn't have this snippet. I think creating a custom hook is a really cool feature of `react.js` and just modifying `rfc` snippet is a lot of work in the long run so I thought it would be nice to have this snippet also, looking forward to seeing you merge this. Thanks : )

Tested in VSCode custom snippets.