### PR TITLE
Create ednf snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ React 17 is currently supported by `_` prefix.
 |  `exa→` | `export { originalName as aliasName} from 'module'` |
 |  `enf→` | `export const functionName = (params) => { }`       |
 |  `edf→` | `export default (params) => { }`                    |
+| `ednf→` | `export default function functionName(params) { }`  |
 |  `met→` | `methodName = (params) => { }`                      |
 |  `fre→` | `arrayName.forEach(element => { }`                  |
 |  `fof→` | `for(let itemName of objectName { }`                |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -46,6 +46,16 @@
     "body": ["export default (${1:params}) => {", "\t$0", "}", ""],
     "description": "Export default function in ES7 syntax"
   },
+  "exportDefaultNamedFunction": {
+    "prefix": "ednf",
+    "body": [
+      "export default function ${1:functionName}(${2:params}) {",
+      "\t$0",
+      "}",
+      ""
+    ],
+    "description": "Export default named function in ES7 syntax"
+  },
   "method": {
     "prefix": "met",
     "body": ["${1:methodName} = (${2:params}) => {", "\t${0}", "}", ""],
@@ -1859,7 +1869,7 @@
       "}",
       "",
       "export default ${1:${TM_FILENAME_BASE}}"
-     ],
-     "description": "Creates a React Custom Hook with ES7 module system"
-   }
+    ],
+    "description": "Creates a React Custom Hook with ES7 module system"
+  }
 }


### PR DESCRIPTION
Hey @dsznajder thanks for the nice extension!

I've switched to the classic "export default function FunctionName() { }" for my React components, but there's no snippet for that.

This adds the `ednf` snippet & updates the README:
![image](https://user-images.githubusercontent.com/761231/114331567-e988ce00-9b09-11eb-90e5-30f94f1e6657.png)
![image](https://user-images.githubusercontent.com/761231/114331570-eb529180-9b09-11eb-8ea1-770d6ee5119f.png)
