### PR TITLE
Create imrrd snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ React 17 is currently supported by `_` prefix.
 | ----------: | ----------------------------------------------------------------------------------- |
 |      `imr→` | `import React from 'react'`                                                         |
 |     `imrd→` | `import ReactDOM from 'react-dom'`                                                  |
+|    `imrrd→` | `import React from 'react' & import ReactDOM from 'react-dom'`                      |
 |     `imrc→` | `import React, { Component } from 'react'`                                          |
 |    `imrcp→` | `import React, { Component } from 'react' & import PropTypes from 'prop-types'`     |
 |    `imrpc→` | `import React, { PureComponent } from 'react'`                                      |
@@ -216,7 +217,7 @@ React 17 is currently supported by `_` prefix.
 ### Console
 
 | Prefix | Method                                                       |
-|--------|--------------------------------------------------------------|
+| ------ | ------------------------------------------------------------ |
 | `clg→` | `console.log(object)`                                        |
 | `clo→` | `` console.log(`object`, object) ``                          |
 | `clj→` | `` console.log(`object`, JSON.stringify(object, null, 2)) `` |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -200,6 +200,14 @@
     "prefix": "imr",
     "body": ["import React from 'react'", ""]
   },
+  "import React & ReactDOM": {
+    "prefix": "imrrd",
+    "body": [
+      "import React from 'react'",
+      "import ReactDOM from 'react-dom'",
+      ""
+    ]
+  },
   "import ReactDOM": {
     "prefix": "imrd",
     "body": ["import ReactDOM from 'react-dom'", ""]


### PR DESCRIPTION
When using react most people import both React & ReactDOM, but there are only snippets for React and ReactDOM separately.

So I made a snippet to import both React and ReactDOM

imrrd
im = import, r = react, rd = reactDOM
![speed-final-clip](https://user-images.githubusercontent.com/68307669/133537340-1a545aa9-724e-4280-b9bf-83f40c1d34cd.gif)
