### PR TITLE
Change order of useContextSnippet for better auto completion

### DIFF
--- a/src/sourceSnippets/hooks.ts
+++ b/src/sourceSnippets/hooks.ts
@@ -33,7 +33,7 @@ const useContext: HooksSnippet = {
   key: 'useContext',
   prefix: 'useContextSnippet',
   body: [
-    `const ${Placeholders.FirstTab} = useContext(${Placeholders.SecondTab})`,
+    `const ${Placeholders.SecondTab} = useContext(${Placeholders.FirstTab})`,
   ],
 };
 


### PR DESCRIPTION
Change the order of tabs in useContextSnippet so you can first select the context and then get autocompletion for the properties.