### PR TITLE
Issue#299 Docs: Snippets.md still linking to old documentation. 

### DIFF
--- a/docs/Snippets.md
+++ b/docs/Snippets.md
@@ -13,7 +13,7 @@ I.E. `tsrcc`
 
 ### React Hooks
 
-- Hooks from [official docs](https://reactjs.org/docs/hooks-reference.html) are added with hook name as prefix.
+- Hooks from [official docs](https://react.dev/blog/2023/03/16/introducing-react-dev) are added with hook name as prefix.
 
 ### Basic Methods
 


### PR DESCRIPTION
The issue stated

```
https://github.com/ults-io/vscode-react-javascript-snippets/blob/HEAD/docs/Snippets.md

still links to https://reactjs.org/docs/hooks-reference.html
```

I have replaced the link to old documentation with the link to the latest documentation.