### PR TITLE
Add export to tsrafc

### DIFF
--- a/src/sourceSnippets/typescript.ts
+++ b/src/sourceSnippets/typescript.ts
@@ -133,7 +133,7 @@ const typescriptReactArrowFunctionComponent: TypescriptSnippet = {
     ...react,
     '',
     ...propsTypeInterface,
-    `const ${Placeholders.FileName} = (props: Props) => {`,
+    `export const ${Placeholders.FileName} = (props: Props) => {`,
     ...innerComponent,
     '}',
   ],


### PR DESCRIPTION
This PR adds an export to `tsrafc` to mirror [its JavaScript version](https://github.com/ults-io/vscode-react-javascript-snippets/blob/185bb91a0b692c54136663464e8225872c434637/src/sourceSnippets/components.ts#L136C15-L136C15).
