### PR TITLE
change react hooks url in Snippets.md

### DIFF
--- a/docs/Snippets.md
+++ b/docs/Snippets.md
@@ -13,7 +13,7 @@ I.E. `tsrcc`
 
 ### React Hooks
 
-- Hooks from [official docs](https://reactjs.org/docs/hooks-reference.html) are added with hook name as prefix.
+- Hooks from [official docs](https://react.dev/reference/react) are added with hook name as prefix.
 
 ### Basic Methods
 


### PR DESCRIPTION
I changed the URL to react hooks because the link redirects to the old react hooks documentation, so I changed the link to the new react documentation