### PR TITLE
Add className snippet for quick insertion in React Native with NativeWind

### DIFF
--- a/docs/Snippets.md
+++ b/docs/Snippets.md
@@ -44,6 +44,7 @@ I.E. `tsrcc`
 | `cmmb→` | `comment block`                                     |
 |   `cp→` | `const { } = this.props`                            |
 |   `cs→` | `const { } = this.state`                            |
+|   `cln` | `className=""`                                                    |
 
 ### React
 

--- a/src/sourceSnippets/others.ts
+++ b/src/sourceSnippets/others.ts
@@ -41,6 +41,7 @@ type OthersMapping = {
   setTimeOut: 'sto';
   shouldComponentUpdate: 'scu';
   typeofSnippet: 'tpf';
+  classNameSnippet: 'cln';
 };
 
 export type OthersSnippet = SnippetMapping<OthersMapping>;
@@ -407,6 +408,13 @@ const typeofSnippet: OthersSnippet = {
   body: [`typeof ${Placeholders.FirstTab}`],
 };
 
+const classNameSnippet: OthersSnippet = {
+  key: 'classNameSnippet',
+  prefix: 'cln',
+  body: ["className=\"$0\""],
+  description: "Insert className attribute"
+};
+
 export default [
   exportDefault,
   exportDestructing,
@@ -448,4 +456,5 @@ export default [
   hocComponentWithRedux,
   hocComponent,
   typeofSnippet,
+  classNameSnippet
 ];


### PR DESCRIPTION
📌 While working with _React Native and NativeWind_ ,

🤔 I frequently found myself needing to **add the className attribute manually**. **This process was repetitive and lacked autocomplete functionality,** which slowed down my workflow. To enhance productivity and streamline the development process, I created this snippet.👾


**✔Added a new snippet with the prefix  `cln ` that expands to  `className=""` , allowing users to easily insert the class name with a placeholder for quick editing.**